### PR TITLE
Simplify the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -8,21 +8,26 @@ assignees: ""
 
 Please, be as descriptive as possible.  Issues lacking detail, or for any other reason than to report a bug, may be closed without action.
 
-### Expected Functionality (Required)
+### Expected
+<!-- ***(Required)*** Add a concise description of what you expected. -->
 
-### Observed Functionality (Required)
+### Observed
+<!-- ***(Required)*** Add a concise description of what you observed. -->
 
-### Steps to reproduce (Required)
+### Reproduced
+<!-- ***(Required)*** If you cannot reproduce this bug consistently, please elaborate.  List the steps to reproduce the behavior.  For example: -->
 > 1. Go to...
 > 2. Click on...
 > 3. See error...
 
-If applicable, add screenshots, animations, or videos to help illustrate your problem.
+***(Optional)*** If applicable, add screenshots, animations, or videos to help illustrate your problem.
 
 ### Where did you see the bug
-
- - OS:
- - OS version: 
- - Browser (if applicable): 
- - Browser version (if applicable): 
- - Simplenote app version: 
+<!-- ***(Required)*** -->
+- System Make:
+- System Model:
+- OS:
+- OS version: 
+- Browser (if applicable): 
+- Browser version (if applicable): 
+- Simplenote app version: 

--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -15,10 +15,16 @@ assignees: ""
 <!-- ***(Required)*** Add a concise description of what you observed. -->
 
 ### Reproduced
-<!-- ***(Required)*** If you cannot reproduce this bug consistently, please elaborate.  List the steps to reproduce the behavior.  For example: -->
-> 1. Go to...
-> 2. Click on...
-> 3. See error...
+<!--
+***(Required)*** If you cannot reproduce this bug consistently, please elaborate.  List the steps to reproduce the behavior.  For example: 
+1. Go to...
+2. Click on...
+3. See error...
+-->
+
+1.
+2.
+3.
 
 <!-- ***(Optional)*** If applicable, add screenshots, animations, or videos to help illustrate your problem. -->
 

--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -6,24 +6,13 @@ labels: bug
 assignees: ""
 ---
 
-Please, be as descriptive as possible.  Issues lacking detail, or for any other reason than to report a bug, may be closed without action.
+### Expected behavior
 
-### Expected
-***(Required)*** Add a concise description of what you expected.
 
-### Observed
-***(Required)*** Add a concise description of what you observed.
+### Actual behavior
 
-### Reproduced
-***(Required)*** If you cannot reproduce this bug consistently, please elaborate.  List the steps to reproduce the behavior.  For example:
-> 1. Go to...
-> 2. Click on...
-> 3. See error...
 
-***(Optional)*** If applicable, add screenshots, animations, or videos to help illustrate your problem.
+### Steps to reproduce the behavior
 
-***(Required)*** Replace SYSTEM_MAKE, SYSTEM_MODEL, OS_VERSION, and APP_VERSION below with the details for the system running the Simplenote app.  If you reproduced the bug on multiple systems, please add a row for each system.
 
-Make|Model|OS Version|App Version
--|-|-|-
-SYSTEM_MAKE|SYSTEM_MODEL|OS_VERSION|APP_VERSION
+##### Tested on [desktop_web_iOS_or_Android], OS [name_and_version], Browser [name_and_version], Simplenote app [version]

--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -6,23 +6,21 @@ labels: bug
 assignees: ""
 ---
 
-### Screenshots and/or description of expected behavior
- 
- 
-### Screenshots and/or description of observed behavior
- 
- 
-### List the steps to reproduce the behavior
-1. 
-2. 
-3. 
- 
-If you cannot reproduce this bug consistently, please elaborate.
+Please, be as descriptive as possible.  Issues lacking detail, or for any other reason than to report a bug, may be closed without action.
+
+### Expected
+
+### Observed
+
+### List the steps to reproduce
+> 1. Go to...
+> 2. Click on...
+> 3. See error...
 
 If applicable, add screenshots, animations, or videos to help illustrate your problem.
- 
-### ***(Required)*** Where you saw the bug happen
- 
+
+### Where did you see the bug
+
 Please list each place where you saw the bug happen and delete the other items from the list.
  - OS: Mac, Windows, Linux, iOS, Android, Web
  - OS version: 

--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -21,8 +21,7 @@ If applicable, add screenshots, animations, or videos to help illustrate your pr
 
 ### Where did you see the bug
 
-Please list each place where you saw the bug happen and delete the other items from the list.
- - OS: Mac, Windows, Linux, iOS, Android, Web
+ - OS:
  - OS version: 
  - Browser (if applicable): 
  - Browser version (if applicable): 

--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -8,11 +8,11 @@ assignees: ""
 
 Please, be as descriptive as possible.  Issues lacking detail, or for any other reason than to report a bug, may be closed without action.
 
-### Expected
+### Expected Functionality (Required)
 
-### Observed
+### Observed Functionality (Required)
 
-### List the steps to reproduce
+### Steps to reproduce (Required)
 > 1. Go to...
 > 2. Click on...
 > 3. See error...

--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -6,7 +6,7 @@ labels: bug
 assignees: ""
 ---
 
-Please, be as descriptive as possible.  Issues lacking detail, or for any other reason than to report a bug, may be closed without action.
+<!-- Please, be as descriptive as possible.  Issues lacking detail, or for any other reason than to report a bug, may be closed without action. -->
 
 ### Expected
 <!-- ***(Required)*** Add a concise description of what you expected. -->
@@ -20,7 +20,7 @@ Please, be as descriptive as possible.  Issues lacking detail, or for any other 
 > 2. Click on...
 > 3. See error...
 
-***(Optional)*** If applicable, add screenshots, animations, or videos to help illustrate your problem.
+<!-- ***(Optional)*** If applicable, add screenshots, animations, or videos to help illustrate your problem. -->
 
 ### Where did you see the bug
 <!-- ***(Required)*** -->

--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -6,13 +6,24 @@ labels: bug
 assignees: ""
 ---
 
-### Expected behavior
-
-
-### Actual behavior
-
-
-### Steps to reproduce the behavior
-
-
-##### Tested on [desktop_web_iOS_or_Android], OS [name_and_version], Browser [name_and_version], Simplenote app [version]
+### Screenshots and/or description of expected behavior
+ 
+ 
+### Describe what happens instead of the expected behavior
+ 
+ 
+### List the steps to reproduce the behavior
+1. 
+2. 
+3. 
+ 
+If you cannot reproduce this bug consistently, please elaborate.
+ 
+### ***(Required)*** Where you saw the bug happen
+ 
+Please list each place where you saw the bug happen and delete the other items from the list.
+ - OS: Mac, Windows, Linux, iOS, Android, Web
+ - OS version: 
+ - Browser (if applicable): 
+ - Browser version (if applicable): 
+ - Simplenote app version: 

--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -9,7 +9,7 @@ assignees: ""
 ### Screenshots and/or description of expected behavior
  
  
-### Describe what happens instead of the expected behavior
+### Screenshots and/or description of observed behavior
  
  
 ### List the steps to reproduce the behavior
@@ -18,6 +18,8 @@ assignees: ""
 3. 
  
 If you cannot reproduce this bug consistently, please elaborate.
+
+If applicable, add screenshots, animations, or videos to help illustrate your problem.
  
 ### ***(Required)*** Where you saw the bug happen
  


### PR DESCRIPTION
Fixes https://github.com/Automattic/Simplenote-United/issues/77

Taking inspiration from https://github.com/wordpress-mobile/WordPress-iOS/issues/new let's make our bug report template easier to fill out. 

Regarding the "Tested on" section, I tried to simplify it but still include hints on all the available options. Does it make sense? Is anything missing?