### PR TITLE
Update bug report template with a note for urgent bugs + links to each repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -6,6 +6,17 @@ labels: bug
 assignees: ""
 ---
 
+<!-- Internal reporters: If this is an urgent issue (crash, high-impact bug) please come over to #simplenote on Slack to get 👀 on it ASAP, thanks! -->
+
+<!-- If this issue is specific to only one platform, consider searching there to see if it has already been reported, or opening a new issue at:
+
+* iOS: https://github.com/automattic/simplenote-iOS
+* Android: https://github.com/automattic/simplenote-android
+* macOS: https://github.com/automattic/simplenote-macos
+* Windows/Linux and web (app.simplenote.com): https://github.com/automattic/simplenote-electron
+
+ -->
+
 <!-- Please, be as descriptive as possible.  Issues lacking detail, or for any other reason than to report a bug, may be closed without action. -->
 
 ### Expected
@@ -16,7 +27,7 @@ assignees: ""
 
 ### Reproduced
 <!--
-***(Required)*** If you cannot reproduce this bug consistently, please elaborate.  List the steps to reproduce the behavior.  For example: 
+***(Required)*** If you cannot reproduce this bug consistently, please elaborate.  List the steps to reproduce the behavior.  For example:
 1. Go to...
 2. Click on...
 3. See error...
@@ -33,7 +44,7 @@ assignees: ""
 - System Make:
 - System Model:
 - OS:
-- OS version: 
-- Browser (if applicable): 
-- Browser version (if applicable): 
-- Simplenote app version: 
+- OS version:
+- Browser (if applicable):
+- Browser version (if applicable):
+- Simplenote app version:


### PR DESCRIPTION
This adds two notes to the top of the bug report template:

1. Asking internal reporters to come to Slack with urgent issues
2. Linking to the individual repos

See discussion at p2XJRt-2yD-p2